### PR TITLE
rename get.status.im to join.status.im

### DIFF
--- a/themes/navy/layout/index.swig
+++ b/themes/navy/layout/index.swig
@@ -79,8 +79,8 @@
                 <h3>Join the Conversation</h3>
                 <p>We are an open community and happy to answer your questions and help you learn more about Nimbus.
                 <p>
-                    <a href="https://get.status.im/chat/public/status-nimbus">Join us in Status</a>
-                    <span><a href="https://get.status.im/chat/public/status-nimbus"><img src="../img/arrow_ogn.png" /></a></span>
+                    <a href="https://join.status.im/chat/public/status-nimbus">Join us in Status</a>
+                    <span><a href="https://join.status.im/chat/public/status-nimbus"><img src="../img/arrow_ogn.png" /></a></span>
             </div>
         </div>
         <div id="team" class="inner-header">
@@ -91,7 +91,7 @@
             <div class="contribute">
                 <img class="contributor" src="../img/cheatfate.jpg" />
                 <h3>Yevhen Kabanov</h3>
-                <p><a href="https://get.status.im/user/0x04f05d31956e9c918c35c30defe1ab69bc693d27eb3f79d619c3ba4f9f044b2349a79fb38e3a614ce9af1286910aa19bf24b53c18d48e10657cbf615a380928f6e" style="color: #939ba1;">Fluid Stimulating Puma</a></p>
+                <p><a href="https://join.status.im/user/0x04f05d31956e9c918c35c30defe1ab69bc693d27eb3f79d619c3ba4f9f044b2349a79fb38e3a614ce9af1286910aa19bf24b53c18d48e10657cbf615a380928f6e" style="color: #939ba1;">Fluid Stimulating Puma</a></p>
                 <p><a href="https://github.com/cheatfate">See Github profile</a>
                     <span><a href="https://github.com/cheatfate"><img src="../img/arrow_ogn.png" /></a></span>
                 </p>
@@ -99,7 +99,7 @@
             <div class="contribute">
                 <img class="contributor" src="../img/jacek.jpg" />
                 <h3>Jacek Sieka</h3>
-                <p><a href="https://get.status.im/user/0x049bc24b377c7e97bb94ab993e48fcbfe38f96aad43a42418d7f33f5a99f6f89e2af91875bfe045205771f28c93be50380cdfe5772201fde7019d57f7ead9af9b5" style="color: #939ba1;">Piercing Double Honeyeater</a></p>
+                <p><a href="https://join.status.im/user/0x049bc24b377c7e97bb94ab993e48fcbfe38f96aad43a42418d7f33f5a99f6f89e2af91875bfe045205771f28c93be50380cdfe5772201fde7019d57f7ead9af9b5" style="color: #939ba1;">Piercing Double Honeyeater</a></p>
                 <p><a href="https://github.com/arnetheduck">See Github profile</a>
                     <span><a href="https://github.com/arnetheduck"><img src="../img/arrow_ogn.png" /></a></span>
                 </p>
@@ -107,7 +107,7 @@
             <div class="contribute">
                 <img class="contributor" src="../img/mamy.jpg" />
                 <h3>Mamy Ratsimbazafy</h3>
-                <p><a href="https://get.status.im/user/0x04d01118c9cbcf4f9d326c1185bff110d36c96890a37cc47e7ce91e8b53ccc088d9df8c828c0669fb97831502113c1195bb17f1ea25fbccffee6a7fb9e30782a82" style="color: #939ba1;">Damp Soulful Allensbigearedbat</a></p>
+                <p><a href="https://join.status.im/user/0x04d01118c9cbcf4f9d326c1185bff110d36c96890a37cc47e7ce91e8b53ccc088d9df8c828c0669fb97831502113c1195bb17f1ea25fbccffee6a7fb9e30782a82" style="color: #939ba1;">Damp Soulful Allensbigearedbat</a></p>
                 <p><a href="https://github.com/mratsim">See Github profile</a>
                     <span><a href="https://github.com/mratsim"><img src="../img/arrow_ogn.png" /></a></span>
                 </p>
@@ -115,7 +115,7 @@
             <div class="contribute">
                 <img class="contributor" src="../img/zahary.jpg" />
                 <h3>Zahary Karadjov</h3>
-                <p><a href="https://get.status.im/user/0x049004fb151893f7112d754d92c650d6d35f8151ec0eff1c148812f8741474f7f8906436e782432680b40e96a2549c03d3dd7801c50928c2bf15d56f6d7d2e1246" style="color: #939ba1;">Useless Gainsboro Serpent</a></p>
+                <p><a href="https://join.status.im/user/0x049004fb151893f7112d754d92c650d6d35f8151ec0eff1c148812f8741474f7f8906436e782432680b40e96a2549c03d3dd7801c50928c2bf15d56f6d7d2e1246" style="color: #939ba1;">Useless Gainsboro Serpent</a></p>
                 <p><a href="https://github.com/zah">See Github profile</a>
                     <span><a href="https://github.com/zah"><img src="../img/arrow_ogn.png" /></a></span>
                 </p>
@@ -123,7 +123,7 @@
             <div class="contribute">
                 <img class="contributor" src="../img/yuriy.jpg" />
                 <h3>Yuriy Glukhov</h3>
-                <p><a href="https://get.status.im/user/0x0483b5849fddb5c85ef69ebdd7bdf57a87eabc5971736d7e2ff5deea210632dac09dbd82df0f2bbf722cc626f867d0c312b9adb9db3f7be81a5d008c25424ce22d" style="color: #939ba1;">Quarrelsome Lightgoldenrodyellow Anaconda</a></p>
+                <p><a href="https://join.status.im/user/0x0483b5849fddb5c85ef69ebdd7bdf57a87eabc5971736d7e2ff5deea210632dac09dbd82df0f2bbf722cc626f867d0c312b9adb9db3f7be81a5d008c25424ce22d" style="color: #939ba1;">Quarrelsome Lightgoldenrodyellow Anaconda</a></p>
                 <p><a href="https://github.com/yglukhov">See Github profile</a>
                     <span><a href="https://github.com/yglukhov"><img src="../img/arrow_ogn.png" /></a></span>
                 </p>
@@ -131,7 +131,7 @@
             <div class="contribute">
                 <img class="contributor" src="../img/tersec_moot.png" />
                 <h3>Dustin Brody</h3>
-                <p><a href="https://get.status.im/user/0x04ec0447abf1a0f7308b1acd52d0c4db6ebf287f7aea4588ff3a8e943143c4c3852cdf1b89474b829428e9ec1041d9ba47975b6154f970bf13f2ea2d87707d7276" style="color: #939ba1;">Pure Quickwitted Indianglassfish</a></p>
+                <p><a href="https://join.status.im/user/0x04ec0447abf1a0f7308b1acd52d0c4db6ebf287f7aea4588ff3a8e943143c4c3852cdf1b89474b829428e9ec1041d9ba47975b6154f970bf13f2ea2d87707d7276" style="color: #939ba1;">Pure Quickwitted Indianglassfish</a></p>
                 <p>
                     <a href="https://github.com/tersec">See Github profile</a>
                     <span><a href="https://github.com/tersec"><img src="../img/arrow_ogn.png" /></a></span></p>
@@ -140,7 +140,7 @@
             <div class="contribute">
                 <img class="contributor" src="../img/stefan.jpg" />
                 <h3>Ștefan Talpalaru</h3>
-                <p><a href="https://get.status.im/user/0x0479be6aeb209d22f81363d8fc2d199e9cf8edf75731df6d5e4c7f9cb411afaecfd55088e2c8634877203df1f605bf7daaf07245012af2f206d388b80046a0abe8" style="color: #939ba1;">Teeming Frayed Argali</a></p>
+                <p><a href="https://join.status.im/user/0x0479be6aeb209d22f81363d8fc2d199e9cf8edf75731df6d5e4c7f9cb411afaecfd55088e2c8634877203df1f605bf7daaf07245012af2f206d388b80046a0abe8" style="color: #939ba1;">Teeming Frayed Argali</a></p>
                 <p><a href="https://github.com/stefantalpalaru">See Github profile</a>
                     <span><a href="https://github.com/stefantalpalaru"><img src="../img/arrow_ogn.png" /></a></span>
                 </p>
@@ -148,7 +148,7 @@
             <div class="contribute">
                 <img class="contributor" src="../img/kdeme_moot.png" />
                 <h3>Kim De Mey</h3>
-                <p><a href="https://get.status.im/" style="color: #939ba1;"></a></p>
+                <p><a href="https://join.status.im/" style="color: #939ba1;"></a></p>
                 <p><a href="https://github.com/kdeme">See Github profile</a>
                     <span><a href="https://github.com/kdeme"><img src="../img/arrow_ogn.png" /></a></span>
                 </p>

--- a/themes/navy/layout/partial/footer.swig
+++ b/themes/navy/layout/partial/footer.swig
@@ -9,7 +9,7 @@
                     <li class="footer-link footer-link--gt"><a href="https://gitter.im/status-im/nimbus" target="_blank"><span class="footer-icon"></span><span class="footer-link-label">Gitter</span></a></li>
                     <li class="footer-link footer-link--tw"><a href="https://twitter.com/ethnimbus" target="_blank"><span class="footer-icon"></span><span class="footer-link-label">Twitter</span></a></li>
                     <li class="footer-link footer-link--dc"><a href="https://discord.gg/XRxWahP" target="_blank"><span class="footer-icon"></span><span class="footer-link-label">Discord</span></a></li>                    
-                    <li class="footer-link footer-link--st"><a href="https://get.status.im/chat/public/nimbus-general" target="_blank"><span class="footer-icon"></span><span class="footer-link-label">Status</span></a></li>
+                    <li class="footer-link footer-link--st"><a href="https://join.status.im/chat/public/nimbus-general" target="_blank"><span class="footer-icon"></span><span class="footer-link-label">Status</span></a></li>
                   </ul>
                 </div>
 

--- a/themes/navy/layout/partial/header.swig
+++ b/themes/navy/layout/partial/header.swig
@@ -8,7 +8,7 @@
             <li class="header-link header-link--tw"><a href="https://twitter.com/ethnimbus" target="_blank"><span class="header-icon"></span><span class="header-link-label"></span></a></li>
             <li class="header-link header-link--gh"><a href="https://github.com/status-im/nimbus" target="_blank"><span class="header-icon"></span><span class="header-link-label"></span></a></li>
             <li class="header-link header-link--gt"><a href="https://gitter.im/status-im/nimbus" target="_blank"><span class="header-icon"></span><span class="header-link-label"></span></a></li>
-            <li class="header-link header-link--st"><a href="https://get.status.im/chat/public/nimbus-general" target="_blank"><span class="header-icon"></span><span class="header-link-label"></span></a></li>
+            <li class="header-link header-link--st"><a href="https://join.status.im/chat/public/nimbus-general" target="_blank"><span class="header-icon"></span><span class="header-link-label"></span></a></li>
         </ul>
     </div>
 </div>
@@ -32,7 +32,7 @@
             <li><a href="https://status.im/contribute/" class="">Contribute</a></li>
         </ul>
         <div class="mobile-nav-footer">
-            <a href=" https://get.status.im/chat/public/nimbus-general" class="button button--orange">Nimbus Status Chat</a>
+            <a href=" https://join.status.im/chat/public/nimbus-general" class="button button--orange">Nimbus Status Chat</a>
         </div>
         <header class="dropdown">
             <nav>


### PR DESCRIPTION
I've renamed the https://get.status.im/ site to https://join.status.im/ in https://github.com/status-im/infra-misc/commit/d4784edd.

The old links should work due to a CloudFlare HTTP redirect I deployed, but I think a URL like:
https://join.status.im/user/jakubgs
Reads much better as a sentence, which literally reads as "Join Status.im user Jakubgs".