### PR TITLE
Close #61: Fix Docs X-Axis Overflow for long code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Make sure you have [Node.js](https://nodejs.org/) installed first.
 
 1. Open Terminal and navigate to the project root directory,
 2. Run `yarn install`
-3. Run `yarn devel`
-4. Open http://localhost:8000 in a browser
+3. Run `yarn build`
+4. Run `yarn devel`
+5. Open http://localhost:8000 in a browser
 
 This prevents the need for any global installs, and will allow you to have live reloading for any changes you are making.

--- a/themes/navy/source/scss/main.scss
+++ b/themes/navy/source/scss/main.scss
@@ -19,6 +19,7 @@ body {
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   background-color: $colorNimbus;
+  overflow-x: hidden;
 }
 
 .home-wrap {

--- a/themes/navy/source/scss/page.scss
+++ b/themes/navy/source/scss/page.scss
@@ -227,10 +227,12 @@ $color-link-hover: lighten($color-link, 10%);
 .article-content {
   line-height: $line-height;
   color: $color-default;
+  max-width: 90% !important;
   @media print {
     font-size: 12pt;
   }
   p, ol, ul, dl, table, blockquote, iframe, .highlight {
+    max-width: 80% !important;
     margin: 1em 0;
   }
   h1 {
@@ -295,7 +297,7 @@ $color-link-hover: lighten($color-link, 10%);
     }
   }
   img, video {
-    max-width: 100%;
+    max-width: 90%;
   }
   blockquote {
     padding: 0 20px;


### PR DESCRIPTION
Docs were overflowing on the X-Axis when code blocks got too long. Looked like this:

![](https://github.com/yakkomajuri/img-store/blob/master/of.png?raw=true)

That should now be fixed. 

The next step would be to ensure that text in all pages is the occupies the same length. Currently it scales up with the code block length up to the `max-width` limit. 

I also added a line to the README to reflect the actual process for developing locally if you just cloned the repo. 