### PR TITLE
Update Ethereum sharding FAQ, RISC-V links (Nimbus docs)

### DIFF
--- a/source/docs/index.md
+++ b/source/docs/index.md
@@ -3,7 +3,7 @@ title: An Ethereum 2.0 Sharding Client
 
 ## Overview
 
-Nimbus aims to be a [sharding](https://github.com/ethereum/wiki/wiki/Sharding-FAQ) client implementation for the Ethereum Blockchain Application Platform. Because the largest deployment of Ethereum will potentially be on embedded systems, Nimbus will be designed to perform well on IoT and personal mobile devices, including older smartphones with resource-restricted hardware. The extensible, configurable, and modular design of Nimbus will make it production ready for Web 3.0 and will ensure that it can be supported and maintained across all goals of Ethereum 2.0.
+Nimbus aims to be a [sharding](https://eth.wiki/sharding/Sharding-FAQs) client implementation for the Ethereum Blockchain Application Platform. Because the largest deployment of Ethereum will potentially be on embedded systems, Nimbus will be designed to perform well on IoT and personal mobile devices, including older smartphones with resource-restricted hardware. The extensible, configurable, and modular design of Nimbus will make it production ready for Web 3.0 and will ensure that it can be supported and maintained across all goals of Ethereum 2.0.
 
 For a more comprehensive introduction, please read our Nimbus for Newbies post or proceed directly to [getting started](/docs/building.html) if you're already sold.
 
@@ -34,6 +34,6 @@ During the deployment of Status among 40,000 alpha testers, we found that a sign
 
 1.  2014 [SoC](https://en.wikipedia.org/wiki/System_on_a_chip) architectures, such as the [Cortex-A53](https://developer.arm.com/products/processors/cortex-a/cortex-a53) (Samsung Note 4 & [Raspberry Pi 3](https://www.raspberrypi.org/products/raspberry-pi-3-model-b/)) and the Apple A8 (iPhone 6)
 1.  [MIPS](https://en.wikipedia.org/wiki/MIPS_architecture)-based architectures, such as the [Onion Omega2](https://onion.io/omega2/)
-1.  Open-source processors, such as [RISC-V](https://en.wikipedia.org/wiki/RISC-V)
+1.  Open-source processors, such as [RISC-V](https://riscv.org)
 
 When the 2020 scalability goal is fully realised, this constraint will help ensure that Ethereum runs performantly on resource-restricted hardware that is at least 6 years old.


### PR DESCRIPTION
- The Ethereum sharding FAQ page has migrated to a new Wiki at https://eth.wiki/
- RISC-V has a .org site, which may be "better" than a Wikipedia page