### PR TITLE
Update link to github repo after updating username

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -438,8 +438,8 @@ import { Button } from '@acid-info/lsd-react'
         <ProfileCard
           name='Ben'
           imgSrc='https://avatars.githubusercontent.com/u/51288821?v=4'
-          githubUsername='web3-developer'
-          githubLink='https://github.com/web3-developer'
+          githubUsername='bhartnett'
+          githubLink='https://github.com/bhartnett'
         />
       </Grid.Item>
       <Grid.Item>


### PR DESCRIPTION
I've just updated my Github username and I noticed that the link to my github profile on the nimbus website is now broken. This fixes the broken link.